### PR TITLE
Added namecoin domains

### DIFF
--- a/root.json
+++ b/root.json
@@ -12,6 +12,12 @@
             "comment" : "OpenNIC domains"
         },
         {
+            "selector": "\\.bit$",
+            "records" : [],
+            "targets" : ["dns://54.235.73.82/", "dns://178.63.16.21/", "dns://95.211.195.245", "178.32.31.41"],
+            "comment" : "Namecoin domains"
+        },
+        {
             "selector": ".*",
             "records" : [],
             "targets" : ["dns://8.8.8.8/"],


### PR DESCRIPTION
Not sure if multiple DNS servers are allowed like that, but since it's a list I assume they are. That's all the active ones listed on [this page](http://dot-bit.org/HowToBrowseBitDomains#List_of_DNS_servers) at this time. Expect more alternate DNS-roots in the future (as long as they don't conflict)
